### PR TITLE
Upgrade template to support Kubernetes 1.29

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,12 @@ By default, AWS makes the control plane (Kubernetes API) for EKS clusters __avai
 If this is not appropriate for your organisation's risk appetite, then you will need to switch access to private and provide appropriate routing.
 See [Infrastructure security in Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/infrastructure-security.html) for AWS recommendations.
 
+#### Consider adding tighter access controls on EKS nodes
+
+The launch-template for EKS nodes disables access to IMDSv1, to avoid pods from having access to the EKS node metadata.
+
+You should consider whether additional restrictions are required, to prevent unintended access to systems or functionality on your network.
+
 #### Internet Access
 
 All nodes in the cluster have outbound access to the internet via a NAT Gateway and Internet Gateway.

--- a/README.md
+++ b/README.md
@@ -123,13 +123,16 @@ needed, so that it may be tailored to any specific context.
 
 By default, AWS makes the control plane (Kubernetes API) for EKS clusters __available to the internet__ and secures them using IAM.
 If this is not appropriate for your organisation's risk appetite, then you will need to switch access to private and provide appropriate routing.
-See [Infrastructure security in Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/infrastructure-security.html) for AWS recommendations.
+
+See [Infrastructure security in Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/infrastructure-security.html) for recommendations from AWS.
 
 #### Consider adding tighter access controls on EKS nodes
 
 The launch-template for EKS nodes disables access to IMDSv1, to avoid pods from having access to the EKS node metadata.
 
 You should consider whether additional restrictions are required, to prevent unintended access to systems or functionality on your network.
+
+See [Restrict the use of host networking and block access to instance metadata service](https://docs.aws.amazon.com/whitepapers/latest/security-practices-multi-tenant-saas-applications-eks/restrict-the-use-of-host-networking-and-block-access-to-instance-metadata-service.html) for recommendations from AWS.
 
 #### Internet Access
 

--- a/eks-cluster-config/Chart.yaml
+++ b/eks-cluster-config/Chart.yaml
@@ -28,5 +28,5 @@ dependencies:
   version: "2.1.5"
   repository: https://kubernetes-sigs.github.io/aws-efs-csi-driver/
 - name: cluster-autoscaler
-  version: "9.16.2"
+  version: "9.25.0"
   repository: https://kubernetes.github.io/autoscaler

--- a/template.yml
+++ b/template.yml
@@ -497,7 +497,7 @@ Resources:
       LaunchTemplateName: !Sub ${FriendlyStackName}-eks-node-launch-template
       LaunchTemplateData:
         MetadataOptions:
-          HttpPutResponseHopLimit: 1
+          HttpPutResponseHopLimit: 2
           HttpTokens: required
         BlockDeviceMappings:
           - Ebs:

--- a/template.yml
+++ b/template.yml
@@ -45,7 +45,7 @@ Parameters:
   KubernetesVersion:
     Type: String
     Description: The version of Kubernetes to use in the EKS cluster specified as major.minor e.g. 1.20
-    Default: 1.24
+    Default: 1.29
 
   ClusterDiskSize:
     Type: Number
@@ -497,6 +497,7 @@ Resources:
       LaunchTemplateName: !Sub ${FriendlyStackName}-eks-node-launch-template
       LaunchTemplateData:
         MetadataOptions:
+          HttpPutResponseHopLimit: 1
           HttpTokens: required
         BlockDeviceMappings:
           - Ebs:

--- a/template.yml
+++ b/template.yml
@@ -491,11 +491,25 @@ Resources:
       RoleArn: !GetAtt EksClusterRole.Arn
       Version: !Ref KubernetesVersion
 
+  EksNodeLaunchTemplate:
+    Type: AWS::EC2::LaunchTemplate
+    Properties:
+      LaunchTemplateName: !Sub ${FriendlyStackName}-eks-node-launch-template
+      LaunchTemplateData:
+        MetadataOptions:
+          HttpTokens: required
+        BlockDeviceMappings:
+          - Ebs:
+              VolumeSize: !Ref ClusterDiskSize
+              VolumeType: gp2
+              DeleteOnTermination: true
+              Encrypted: false
+            DeviceName: /dev/xvda
+
   EksNodeGroup:
     Type: AWS::EKS::Nodegroup
     Properties:
       ClusterName: !Ref EksCluster
-      DiskSize: !Ref ClusterDiskSize
       InstanceTypes:
         - !Ref ClusterNodeSize
       NodeRole: !GetAtt EksNodeInstanceRole.Arn
@@ -506,6 +520,8 @@ Resources:
       Subnets:
         - !Ref NodesSubnetA
         - !Ref NodesSubnetB
+      LaunchTemplate:
+        Id: !Ref EksNodeLaunchTemplate
 
   #######
   # EFS #


### PR DESCRIPTION
Alongside the version upgrade, this change adds a launch template to the EKS node group, to disable use of IMDSv1 on AWS EC2 instances used as EKS nodes.