### PR TITLE
Improve cluster's resilience and simplify dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ is" with the default values or can be customised with the parameters below:
 | VpcFlowLogRetentionInDays | Specifies the number of days you want to retain log events. | 14 |
 | VpcFlowLogTrafficType | The type of traffic to log. | ALL |
 | PublicSubnetACidrBlock | The CIDR block to be used by the public subnet in availability zone A. | 10.0.1.0/24 |
+| PublicSubnetBCidrBlock | The CIDR block to be used by the public subnet in availability zone B. | 10.0.2.0/24 |
 | NodesSubnetACidrBlock | The CIDR block to be used by the nodes subnet in availability zone A. | 10.0.11.0/24 |
 | NodesSubnetBCidrBlock | The CIDR block to be used by the nodes subnet in availability zone B. | 10.0.12.0/24 |
 | KubernetesVersion | The version of Kubernetes to use in the EKS cluster specified as major.minor e.g. 1.29 | 1.29 |

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ The template creates two IAM policies: one for administering the key, and the ot
 The Cluster Configuration installs the Kubernetes resources that are prerequisites to the Burp Suite DAST application using a
 [Helm chart](eks-cluster-config/Chart.yaml). In the case of AWS EKS, this includes:
 
-* [AWS EFS CSI driver](https://github.com/kubernetes-sigs/aws-efs-csi-driver).
+* AWS EFS CSI driver (installed as an [EKS managed add-on](https://docs.aws.amazon.com/eks/latest/userguide/efs-csi.html) via the CloudFormation template).
 * [Kubernetes cluster-autoscaler](https://github.com/kubernetes/autoscaler/tree/master/charts/cluster-autoscaler).
 * A [PersistentVolume](eks-cluster-config/templates/persistent-volume.yml) and [PersistentVolumeClaim](eks-cluster-config/templates/persistent-volume-claim.yml) using the EFS driver.
 * A LoadBalancer service that provisions an AWS load balancer to enable external access to Burp Suite DAST (once deployed).

--- a/eks-cluster-config/Chart.yaml
+++ b/eks-cluster-config/Chart.yaml
@@ -24,9 +24,6 @@ version: 0.1.0
 appVersion: 0.1.0
 
 dependencies:
-- name: aws-efs-csi-driver
-  version: "2.1.5"
-  repository: https://kubernetes-sigs.github.io/aws-efs-csi-driver/
 - name: cluster-autoscaler
   version: "9.25.0"
   repository: https://kubernetes.github.io/autoscaler

--- a/eks-cluster-config/values.yaml
+++ b/eks-cluster-config/values.yaml
@@ -19,21 +19,3 @@ cluster-autoscaler:
     requests:
       cpu: 100m
       memory: 300Mi
-
-aws-efs-csi-driver:
-  controller:
-    resources:
-      limits:
-        cpu: 100m
-        memory: 128Mi
-      requests:
-        cpu: 100m
-        memory: 128Mi
-  node:
-    resources:
-      limits:
-        cpu: 100m
-        memory: 128Mi
-      requests:
-        cpu: 100m
-        memory: 128Mi

--- a/template.yml
+++ b/template.yml
@@ -32,6 +32,11 @@ Parameters:
     Description: The CIDR block to be used by the public subnet in availability zone A
     Default: 10.0.1.0/24
 
+  PublicSubnetBCidrBlock:
+    Type: String
+    Description: The CIDR block to be used by the public subnet in availability zone B
+    Default: 10.0.2.0/24
+
   NodesSubnetACidrBlock:
     Type: String
     Description: The CIDR block to be used by the nodes subnet in availability zone A
@@ -394,6 +399,9 @@ Resources:
           Ref: "AWS::Region"
       CidrBlock: !Ref PublicSubnetACidrBlock
       MapPublicIpOnLaunch: false
+      Tags:
+        - Key: kubernetes.io/role/elb
+          Value: "1"
       VpcId: !Ref VPC
 
   PublicSubnetARouteTableAssociation:
@@ -401,6 +409,26 @@ Resources:
     Properties:
       RouteTableId: !Ref PublicRouteTable
       SubnetId: !Ref PublicSubnetA
+
+  PublicSubnetB:
+    Type: AWS::EC2::Subnet
+    Properties:
+      AvailabilityZone: !Select
+        - 1
+        - !GetAZs
+          Ref: "AWS::Region"
+      CidrBlock: !Ref PublicSubnetBCidrBlock
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: kubernetes.io/role/elb
+          Value: "1"
+      VpcId: !Ref VPC
+
+  PublicSubnetBRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      SubnetId: !Ref PublicSubnetB
 
   NatGatewayAEip:
     Type: AWS::EC2::EIP
@@ -419,6 +447,23 @@ Resources:
         - Key: Name
           Value: !Sub ${FriendlyStackName}-nat-gateway-a
 
+  NatGatewayBEip:
+    Type: AWS::EC2::EIP
+    Properties:
+      Domain: vpc
+      Tags:
+        - Key: Name
+          Value: !Sub ${FriendlyStackName}-nat-gateway-b-eip
+
+  NatGatewayB:
+    Type: AWS::EC2::NatGateway
+    Properties:
+      AllocationId: !GetAtt NatGatewayBEip.AllocationId
+      SubnetId: !Ref PublicSubnetB
+      Tags:
+        - Key: Name
+          Value: !Sub ${FriendlyStackName}-nat-gateway-b
+
   PrivateRouteTable:
     Type: AWS::EC2::RouteTable
     Properties:
@@ -433,6 +478,21 @@ Resources:
       RouteTableId: !Ref PrivateRouteTable
       DestinationCidrBlock: 0.0.0.0/0
       NatGatewayId: !Ref NatGatewayA
+
+  PrivateRouteTableB:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref VPC
+      Tags:
+        - Key: Name
+          Value: !Sub ${FriendlyStackName}-private-route-table-b
+
+  NatGatewayBRoute:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref PrivateRouteTableB
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId: !Ref NatGatewayB
 
   NodesSubnetA:
     Type: AWS::EC2::Subnet
@@ -469,7 +529,7 @@ Resources:
   NodesSubnetBRouteTableAssociation:
     Type: AWS::EC2::SubnetRouteTableAssociation
     Properties:
-      RouteTableId: !Ref PrivateRouteTable
+      RouteTableId: !Ref PrivateRouteTableB
       SubnetId: !Ref NodesSubnetB
 
   #######
@@ -489,6 +549,8 @@ Resources:
           Resources:
             - secrets
       RoleArn: !GetAtt EksClusterRole.Arn
+      UpgradePolicy:
+        SupportType: STANDARD
       Version: !Ref KubernetesVersion
 
   EksNodeLaunchTemplate:

--- a/template.yml
+++ b/template.yml
@@ -586,6 +586,12 @@ Resources:
       LaunchTemplate:
         Id: !Ref EksNodeLaunchTemplate
 
+  EfsCSIDriverAddon:
+    Type: AWS::EKS::Addon
+    Properties:
+      AddonName: aws-efs-csi-driver
+      ClusterName: !Ref EksCluster
+
   #######
   # EFS #
   #######


### PR DESCRIPTION
Improve resilience and availability of the cluster by adding a public subnet in the other availability zone reachable via the load balancer.

Also set the EKS cluster update policy to STANDARD by default and replace the efs-csi-driver helm chart dependency with the EKS add-on.